### PR TITLE
Add snapshot for cardano-node 1.10.1

### DIFF
--- a/snapshots/cardano-1.10.1.yaml
+++ b/snapshots/cardano-1.10.1.yaml
@@ -32,6 +32,7 @@ packages:
 - prometheus-2.1.2
 - quickcheck-instances-0.3.19
 - QuickCheck-2.12.6.1
+- quiet-0.2
 - snap-core-1.0.4.1
 - snap-server-1.1.1.1
 - statistics-linreg-0.3
@@ -53,7 +54,7 @@ packages:
   - cborg
 
 - git: https://github.com/input-output-hk/cardano-base
-  commit: 742a789a520387c6cd30a4ca28bc4fc8588a41c7
+  commit: 42c57fed487b61c13a68a1600a6675ad987822d0
   subdirs:
   - binary
   - binary/test
@@ -64,7 +65,7 @@ packages:
   commit: 2547ad1e80aeabca2899951601079408becbc92c
 
 - git: https://github.com/input-output-hk/cardano-ledger
-  commit: 90b14c056059d0082cb2641f9c77cb1b097be329
+  commit: 357ed656ad81fcddb401ceb656d6c2a6a177a0fa
   subdirs:
   - cardano-ledger
   - cardano-ledger/test
@@ -72,7 +73,7 @@ packages:
   - crypto/test
 
 - git: https://github.com/input-output-hk/cardano-ledger-specs
-  commit: f1d5ddb25531b2512796d34e9cfd803f7af76567
+  commit: 5c5854be017f75c703b11c1aad4b765f511ee70e
   subdirs:
   - semantics/executable-spec # small-steps
   - byron/ledger/executable-spec    # cs-ledger
@@ -110,7 +111,7 @@ packages:
   - tracer-transformers
 
 - git: https://github.com/input-output-hk/ouroboros-network
-  commit: 3d89fa475bc740473e5ffe947572c19f9b91d26d
+  commit: dbc48d30c5e3a46d28b7c25a15141d3518982c70
   subdirs:
   - io-sim
   - io-sim-classes


### PR DESCRIPTION
Updated dependencies for the [cardano-node 1.10.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.10.1) release.

* Git revisions are copied from `cardano-node/cabal.project`.

* Needed to add `quiet-0.2` to the snapshot.

* Tested locally in `cardano-wallet` by adjusting the resolver in `stack.yaml` and running `stack build --test --no-run-tests --bench --no-run-benchmarks`.
