### PR TITLE
Add snapshot for cardano-node 1.11.0

### DIFF
--- a/snapshots/README.md
+++ b/snapshots/README.md
@@ -4,6 +4,8 @@ Available [Stack](https://docs.haskellstack.org/en/stable/README/) snapshots for
 
 # Available Snapshots
 
+- [cardano-1.11.0](https://raw.githubusercontent.com/input-output-hk/cardano-haskell/master/snapshots/cardano-1.11.0.yaml)
+- [cardano-1.10.1](https://raw.githubusercontent.com/input-output-hk/cardano-haskell/master/snapshots/cardano-1.10.1.yaml)
 - [cardano-1.10.0](https://raw.githubusercontent.com/input-output-hk/cardano-haskell/master/snapshots/cardano-1.10.0.yaml)
 - [cardano-1.9.3](https://raw.githubusercontent.com/input-output-hk/cardano-haskell/master/snapshots/cardano-1.9.3.yaml)
 - [cardano-1.9.2](https://raw.githubusercontent.com/input-output-hk/cardano-haskell/master/snapshots/cardano-1.9.2.yaml)

--- a/snapshots/cardano-1.11.0.yaml
+++ b/snapshots/cardano-1.11.0.yaml
@@ -1,0 +1,132 @@
+name: cardano-1.11.0
+
+resolver: lts-14.25
+
+packages:
+- base16-0.1.2.1
+- base58-bytestring-0.1.0
+- base64-0.4.1
+- bimap-0.4.0
+- binary-0.8.7.0
+- brick-0.47
+- canonical-json-0.6.0.0
+- clock-0.8
+- config-ini-0.2.4.0
+- connection-0.3.1
+- containers-0.5.11.0
+- data-clist-0.1.2.2
+- dns-3.0.4
+- generic-monoid-0.1.0.0
+- gray-code-0.3.1
+- hedgehog-1.0.2
+- hspec-2.7.0
+- hspec-core-2.7.0
+- hspec-discover-2.7.0
+- io-streams-1.5.1.0
+- io-streams-haproxy-1.0.1.0
+- katip-0.8.3.0
+- libsystemd-journal-1.4.4
+- micro-recursion-schemes-5.0.2.2
+- moo-1.2
+- network-3.1.1.1
+- prometheus-2.1.2
+- quickcheck-instances-0.3.19
+- QuickCheck-2.12.6.1
+- quiet-0.2
+- snap-core-1.0.4.1
+- snap-server-1.1.1.1
+- statistics-linreg-0.3
+- streaming-binary-0.3.0.1
+- tasty-hedgehog-1.0.0.2
+- text-1.2.4.0
+- text-zipper-0.10.1
+- th-lift-instances-0.1.14
+- time-units-1.0.0
+- transformers-except-0.1.1
+- Unique-0.4.7.6
+- websockets-0.12.6.1
+- Win32-2.6.2.0
+- word-wrap-0.4.1
+
+- git: https://github.com/well-typed/cborg
+  commit: 42a83192749774268337258f4f94c97584b80ca6
+  subdirs:
+  - cborg
+
+- git: https://github.com/input-output-hk/cardano-base
+  commit: 2cc27584bb19bd5be9f1721fd4a2393bb99c6119
+  subdirs:
+  - binary
+  - binary/test
+  - cardano-crypto-class
+  - slotting
+
+- git: https://github.com/input-output-hk/cardano-crypto
+  commit: 2547ad1e80aeabca2899951601079408becbc92c
+
+- git: https://github.com/input-output-hk/cardano-ledger
+  commit: 9ee8a6630a8719ba54554c3ce10c555bf5dff4cc
+  subdirs:
+  - cardano-ledger
+  - cardano-ledger/test
+  - crypto
+  - crypto/test
+
+- git: https://github.com/input-output-hk/cardano-ledger-specs
+  commit: 52afaab4fe99df8fff1e7666e665a923118cfc53
+  subdirs:
+  - semantics/executable-spec # small-steps
+  - byron/ledger/executable-spec    # cs-ledger
+  - byron/chain/executable-spec     # cs-blockchain
+  - shelley/chain-and-ledger/dependencies/non-integer
+  - shelley/chain-and-ledger/executable-spec
+  - shelley/chain-and-ledger/executable-spec/test
+
+- git: https://github.com/input-output-hk/cardano-prelude
+  commit: 91f357abae16099858193b999807323ca9a7c63c
+  subdirs:
+  - .
+  - test
+
+- git: https://github.com/input-output-hk/cardano-shell
+  commit: 8387be2c5d4f7060a48bceae119973c6382df57c
+  subdirs:
+  - cardano-shell
+
+- git: https://github.com/input-output-hk/cardano-sl-x509
+  commit: 43a036c5bbe68ca2e9cbe611eab7982e2348fe49
+
+- git: https://github.com/input-output-hk/goblins
+  commit: 26d35ad52fe9ade3391532dbfeb2f416f07650bc
+
+- git: https://github.com/input-output-hk/iohk-monitoring-framework
+  commit: 8f7d2a4ba4288e528fea62946b525f493c26ae7a
+  subdirs:
+  - contra-tracer
+  - iohk-monitoring
+  - plugins/backend-aggregation
+  - plugins/backend-ekg
+  - plugins/backend-monitoring
+  - plugins/scribe-systemd
+  - tracer-transformers
+
+- git: https://github.com/input-output-hk/ouroboros-network
+  commit: ec4f3af58c13a4c20116e9e262b048fb2d27bdc3
+  subdirs:
+  - io-sim
+  - io-sim-classes
+  - network-mux
+  - ntp-client
+  - Win32-network
+  - ouroboros-consensus
+  - ouroboros-consensus-byron
+  - ouroboros-consensus-byronspec
+  - ouroboros-consensus-cardano
+  - ouroboros-consensus-shelley
+  - ouroboros-consensus/ouroboros-consensus-mock
+  - ouroboros-consensus/ouroboros-consensus-test-infra
+  - ouroboros-network
+  - ouroboros-network-framework
+  - ouroboros-network-testing
+  - typed-protocols
+  - typed-protocols-examples


### PR DESCRIPTION
https://github.com/input-output-hk/cardano-node/releases/tag/1.11.0

PR input-output-hk/cardano-wallet#1593 builds with this snapshot.
