### PR TITLE
Add 1.26.1 snapshot

### DIFF
--- a/snapshots/cardano-1.26.1.yaml
+++ b/snapshots/cardano-1.26.1.yaml
@@ -1,6 +1,6 @@
 name: cardano-1.26.1
 
-resolver: lts-17.6
+resolver: lts-17.9
 
 packages:
 # Packages that exist in LTS, but which we use a different version of,

--- a/snapshots/cardano-1.26.1.yaml
+++ b/snapshots/cardano-1.26.1.yaml
@@ -1,0 +1,119 @@
+name: cardano-1.26.1
+
+resolver: lts-17.6
+
+packages:
+# Packages that exist in LTS, but which we use a different version of,
+# or just want to explicitly pin.
+- base16-bytestring-1.0.1.0 # 0.1.1.7 on LTS 17.6; would break cardano-base
+- bech32-1.1.0
+- bech32-th-1.0.2
+- Cabal-3.4.0.0
+- parsec-3.1.14.0
+
+# Packages not in LTS
+- Unique-0.4.7.6
+- Win32-2.6.2.0
+- canonical-json-0.6.0.0
+- gray-code-0.3.1
+- ip-1.5.1
+- libsystemd-journal-1.4.4
+- micro-recursion-schemes-5.0.2.2
+- moo-1.2
+- nothunks-0.1.2
+- partial-order-0.2.0.0
+- regex-posix-clib-2.7
+- statistics-linreg-0.3
+- streaming-binary-0.2.2.0
+- transformers-except-0.1.1
+
+- git: https://github.com/input-output-hk/cardano-base
+  commit: 101e7752cf4b23fd0b411736f523b8f6c43f6bc2
+  subdirs:
+  - binary
+  - binary/test
+  - cardano-crypto-class
+  - cardano-crypto-tests
+  - cardano-crypto-praos
+  - slotting
+
+- git: https://github.com/input-output-hk/cardano-crypto
+  commit: f73079303f663e028288f9f4a9e08bcca39a923e
+
+- git: https://github.com/input-output-hk/cardano-ledger-specs
+  commit: 0730828363ad6d0669b7a5a12635e22944b32880
+  subdirs:
+  - byron/chain/executable-spec
+  - byron/crypto
+  - byron/crypto/test
+  - byron/ledger/executable-spec
+  - byron/ledger/impl
+  - byron/ledger/impl/test
+  - semantics/executable-spec
+  - semantics/small-steps-test
+  - shelley/chain-and-ledger/dependencies/non-integer
+  - shelley/chain-and-ledger/executable-spec
+  - shelley/chain-and-ledger/shelley-spec-ledger-test
+  - shelley-ma/impl
+
+- git: https://github.com/input-output-hk/cardano-node
+  commit: 62f38470098fc65e7de5a4b91e21e36ac30799f3
+  subdirs:
+  - cardano-api
+  - cardano-api/test
+  - cardano-cli
+  - cardano-config
+  - cardano-node
+  - cardano-node-chairman
+  - hedgehog-extras
+
+- git: https://github.com/input-output-hk/cardano-prelude
+  commit: ee4e7b547a991876e6b05ba542f4e62909f4a571
+  subdirs:
+  - cardano-prelude
+  - cardano-prelude-test
+
+- git: https://github.com/input-output-hk/cardano-sl-x509
+  commit: 12925934c533b3a6e009b61ede555f8f26bac037
+
+- git: https://github.com/input-output-hk/goblins
+  commit: cde90a2b27f79187ca8310b6549331e59595e7ba
+
+- git: https://github.com/input-output-hk/iohk-monitoring-framework
+  commit: f6ab0631275d04dff1b990283bbf9671093e7505
+  subdirs:
+  - contra-tracer
+  - iohk-monitoring
+  - plugins/backend-aggregation
+  - plugins/backend-ekg
+  - plugins/backend-monitoring
+  - plugins/backend-trace-forwarder
+  - plugins/scribe-systemd
+  - tracer-transformers
+
+- git: https://github.com/input-output-hk/ouroboros-network
+  commit: 7f90c8c59ffc7d61a4e161e886d8962a9c26787a
+  subdirs:
+  - io-sim
+  - io-sim-classes
+  - network-mux
+  - ouroboros-consensus
+  - ouroboros-consensus-byron
+  - ouroboros-consensus-cardano
+  - ouroboros-consensus-shelley
+  - ouroboros-network
+  - ouroboros-network-framework
+  - typed-protocols
+  - typed-protocols-examples
+  # Extra packages not used by cardano-node
+  - cardano-client
+  - ntp-client
+  - ouroboros-consensus-mock
+
+- git: https://github.com/input-output-hk/Win32-network
+  commit: 94153b676617f8f33abe8d8182c37377d2784bd1
+
+- git: https://github.com/snoyberg/http-client.git
+  commit: 1a75bdfca014723dd5d40760fad854b3f0f37156
+  subdirs:
+  - http-client

--- a/snapshots/cardano-1.26.1.yaml
+++ b/snapshots/cardano-1.26.1.yaml
@@ -10,6 +10,7 @@ packages:
 - bech32-th-1.0.2
 - Cabal-3.4.0.0
 - parsec-3.1.14.0
+- async-timer-0.2.0.0
 
 # Packages not in LTS
 - Unique-0.4.7.6


### PR DESCRIPTION
## Issue

[ADP-845](https://jira.iohk.io/browse/ADP-845)

## Description

For cardano-wallet and cardano-transactions bump

`diff snapshots/cardano-1.25.1.yaml snapshots/cardano-1.26.1.yaml`

```diff
1c1
< name: cardano-1.25.1-GHC-8.10.4
---
> name: cardano-1.26.1
8c8
< - base16-bytestring-1.0.1.0
---
> - base16-bytestring-1.0.1.0 # 0.1.1.7 on LTS 17.6; would break cardano-base
11,16c11,12
< - containers-0.5.11.0 # 0.6.2.1 on LTS 17.6
< - dns-3.0.4 # 4.0.1 on LTS 17.6
< - micro-recursion-schemes-5.0.2.2
< - network-3.1.2.1 # 3.1.1.1 on LTS 17.6
< - text-1.2.4.0 # 1.2.4.1 on LTS 17.6
< - binary-0.8.7.0 # 0.8.8.0 on LTS 17.6
---
> - Cabal-3.4.0.0
> - parsec-3.1.14.0
19c15,16
< - moo-1.2
---
> - Unique-0.4.7.6
> - Win32-2.6.2.0
21,23d17
< - partial-order-0.2.0.0
< - nothunks-0.1.2
< - transformers-except-0.1.1
25c19
< - Unique-0.4.7.6
---
> - ip-1.5.1
27c21,24
< - Win32-2.6.2.0
---
> - micro-recursion-schemes-5.0.2.2
> - moo-1.2
> - nothunks-0.1.2
> - partial-order-0.2.0.0
31c28
< - ip-1.5.1
---
> - transformers-except-0.1.1
34c31
<   commit: b364d925e0a72689ecba40dd1f4899f76170b894
---
>   commit: 101e7752cf4b23fd0b411736f523b8f6c43f6bc2
47c44
<   commit: 097890495cbb0e8b62106bcd090a5721c3f4b36f
---
>   commit: 0730828363ad6d0669b7a5a12635e22944b32880
63c60
<   commit: 9a7331cce5e8bc0ea9c6bfa1c28773f4c5a7000f
---
>   commit: 62f38470098fc65e7de5a4b91e21e36ac30799f3
85d81
<   # NOTE: Bumped
87c83
<   commit: 563e79f28c6da5c547463391d4c58a81442e48db
---
>   commit: f6ab0631275d04dff1b990283bbf9671093e7505
99c95
<   commit: 6cb9052bde39472a0555d19ade8a42da63d3e904
---
>   commit: 7f90c8c59ffc7d61a4e161e886d8962a9c26787a
```