### PR TITLE
Include IOG forks of `haskell-lmdb` and `lmdb-simple` for UTxO HD.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ plutus/
 typed-protocols/
 Win32-network/
 
-mainnet
+mainnet*/

--- a/.gitignore
+++ b/.gitignore
@@ -22,10 +22,14 @@ cardano-transactions/
 cardano-wallet/
 flat/
 goblins/
+haskell-lmdb/
 hedgehog-extras/
+io-sim/
 iohk-monitoring-framework/
+lmdb-simple/
 ouroboros-network/
 plutus/
+typed-protocols/
 Win32-network/
 
 mainnet

--- a/cabal.project
+++ b/cabal.project
@@ -4,6 +4,14 @@ packages:
   ouroboros-network/*/*.cabal
   Win32-network
 
+  io-sim/io-classes
+  io-sim/io-sim
+  io-sim/strict-stm
+
+  typed-protocols/typed-protocols
+  typed-protocols/typed-protocols-cborg
+  typed-protocols/typed-protocols-examples
+
   cardano-ledger/*/*/*.cabal
   cardano-ledger/*/*/*/*.cabal
   cardano-ledger/*/*/*/*/*.cabal
@@ -49,6 +57,10 @@ packages:
   cardano-node/trace-dispatcher
   cardano-node/trace-forward
   cardano-node/trace-resources
+
+  lmdb-simple
+
+  haskell-lmdb
 
 --  cardano-node/cardano-submit-api
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,16 +1,12 @@
-index-state: 2022-02-18T00:00:00Z
+index-state: 2022-07-01T00:00:00Z
 
 packages:
   ouroboros-network/*/*.cabal
   Win32-network
 
-  io-sim/io-classes
-  io-sim/io-sim
-  io-sim/strict-stm
+  io-sim/*/*.cabal
 
-  typed-protocols/typed-protocols
-  typed-protocols/typed-protocols-cborg
-  typed-protocols/typed-protocols-examples
+  typed-protocols/*/*.cabal
 
   cardano-ledger/*/*/*.cabal
   cardano-ledger/*/*/*/*.cabal
@@ -73,9 +69,6 @@ packages:
 --  cardano-addresses/*/*.cabal
 --  cardano-transactions
 
-  haskell-lmdb
-  lmdb-simple
-
 tests: True
 
 -- There is a cyclic dependency between io-sim and typed-protocols-examples
@@ -130,6 +123,9 @@ package cardano-shell
 package plutus-core
   tests: False
 
+package lmdb
+  flags: +use-pkg-config
+
 max-backjumps: 10000
 
 allow-newer:
@@ -167,3 +163,15 @@ source-repository-package
   location: https://github.com/vshabanov/ekg-json
   tag: 00ebe7211c981686e65730b7144fbf5350462608
   --sha256: 1zvjm3pb38w0ijig5wk5mdkzcszpmlp5d4zxvks2jk1rkypi8gsm
+
+constraints:
+    hedgehog >= 1.0
+  , bimap >= 0.4.0
+  , libsystemd-journal >= 1.4.4
+  , systemd >= 2.3.0
+    -- systemd-2.3.0 requires at least network 3.1.1.0 but it doesn't declare
+    -- that dependency
+  , network >= 3.1.1.0
+  , HSOpenSSL >= 0.11.7.2
+  , algebraic-graphs < 0.7
+  , protolude < 0.3.1

--- a/cabal.project
+++ b/cabal.project
@@ -73,6 +73,9 @@ packages:
 --  cardano-addresses/*/*.cabal
 --  cardano-transactions
 
+  haskell-lmdb
+  lmdb-simple
+
 tests: True
 
 -- There is a cyclic dependency between io-sim and typed-protocols-examples


### PR DESCRIPTION
Can we merge this ahead of full UTxO HD integration with the consensus `main` branch, or should we wait?

Corresponding `cardano-repo-tool` PR:
https://github.com/input-output-hk/cardano-repo-tool/pull/25